### PR TITLE
Add Support for `char` Primitive Type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,16 @@ derefs!(
     Arc<T>
 );
 
+impl CompileConst for char {
+    fn const_type() -> String {
+        "char".to_owned()
+    }
+
+    fn const_val(&self) -> String {
+        format!("'{}'", *self)
+    }
+}
+
 impl CompileConst for bool {
     fn const_type() -> String {
         "bool".to_owned()


### PR DESCRIPTION
This PR introduces basic support for the `char` primitive type.  
It may potentially cause issues with character escaping.  
However, since the existing implementation for `String` doesn't handle those cases either,  
I've opted for a simple implementation that similarly doesn't address escaping intricacies.